### PR TITLE
Uses .forRoot() instead of static()

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ import {CalendarModule} from "ap-angular2-fullcalendar";
 
 @NgModule({
   imports: [
-    CalendarModule
+    CalendarModule.forRoot()
   ],
 })
 export class AppModule {}

--- a/angular2-fullcalendar.ts
+++ b/angular2-fullcalendar.ts
@@ -15,7 +15,7 @@ import { CommonModule } from "@angular/common";
 })
 
 export class CalendarModule {
-    static(): ModuleWithProviders {
+    static forRoot(): ModuleWithProviders {
         return {
             ngModule: CalendarModule,
             providers: []

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Angular2 component for FullCalendar",
   "main": "index.js",
   "scripts": {
-    "build": "rm -rf dist/ && ngc",
+    "build": "ngc build -p ./tsconfig.json",
     "release": "npm run build && cp package.json dist/ && cd dist/ && npm publish && cd .."
   },
   "repository": {
@@ -31,11 +31,12 @@
     "@types/jquery": "2.0.41",
     "@types/moment": "2.13.0",
     "@types/node": "7.0.12",
-    "fullcalendar": "3.3.0"
+    "fullcalendar": "3.3.0",
+    "ngc": "^1.0.0"
   },
   "devDependencies": {
     "@angular/compiler": "4.0.0",
-    "@angular/compiler-cli": "4.0.0",
+    "@angular/compiler-cli": "^4.0.0",
     "@angular/platform-browser": "4.0.0",
     "ng2-datepicker": "2.0.0-dev5",
     "rxjs": "5.2.0",


### PR DESCRIPTION
This fixes the following issue:
https://github.com/lbertenasco/ap-ng2-fullcalendar/issues/3

